### PR TITLE
Add additional callsign information output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,7 +420,7 @@ dependencies = [
 
 [[package]]
 name = "hrt"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "config 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 name = "hrt"
 readme = "README.md"
 repository = "https://github.com/beaorn/hrt"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2019 Bryce Johnston, KE0TSN
+Copyright (c) 2019 Bryce Johnston, K0NYX
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -56,8 +56,10 @@ example output:
 ```
 K0NYX (HamQTH)
   Name: Bryce Johnston
-  Location: Manhattan, KS
-  Country United States
+  Email: bryce@beaorn.com
+  Address: 100 Antenna Way
+  Location: Manhattan, KS 66502
+  Country: United States
 ```
 
 ### DXCC lookup

--- a/README.md
+++ b/README.md
@@ -33,30 +33,32 @@ You will need to set your account info in `.hrt.toml` for [qrz](https://www.qrz.
 
 Lookup with QRZ:
 ```bash
-hrt call C4LLS1GN
+hrt call K0NYX
 ```
 
 example output:
 ```
-C4LLS1GN (QRZ)
-  Name: Nikola Tesla
-  Location: Colorado Springs, CO, United States
-  Class: E
+K0NYX (QRZ)
+  Name: Bryce Johnston
+  Email: bryce@beaorn.com
+  Address: 100 Antenna Way
+  Location: Manhattan, KS 66502
+  Country: United States
+  Class: G
 ```
 
 Use alternative lookup source HamQTH:
 ```bash
-hrt call C4LLS1GN -s hamqth
+hrt call K0NYX -s hamqth
 ```
 
 example output:
 ```
-c4lls1gn (HamQTH)
-  Name: Nikola Tesla
-  Location: Colorado Springs, CO, United States
+K0NYX (HamQTH)
+  Name: Bryce Johnston
+  Location: Manhattan, KS
+  Country United States
 ```
-
-Call command arguments will be added to allow returning additional information.
 
 ### DXCC lookup
 
@@ -92,7 +94,7 @@ example output:
 
 Lookup by callsign
 ```bash
-hrt dxcc C4LLS1GN
+hrt dxcc K0NYX
 ```
 
 example output:
@@ -106,7 +108,7 @@ example output:
 
 Use alternative lookup source HamQTH:
 ```bash
-hrt dxcc C4LLS1GN -s hamqth
+hrt dxcc K0NYX -s hamqth
 ```
 
 example output:

--- a/src/cli.yml
+++ b/src/cli.yml
@@ -1,6 +1,6 @@
 name: hrt
 version: "0.1.0"
-author: Bryce Johnston, KE0TSN. <bryce@beaorn.com>
+author: Bryce Johnston, K0NYX. <bryce@beaorn.com>
 about: Ham Radio related command line tools
 subcommands:
     - init:

--- a/src/hamqth.rs
+++ b/src/hamqth.rs
@@ -309,9 +309,23 @@ pub fn query(callsign: &str) -> Result<(), reqwest::Error> {
     } else if hqth.session.error != "" {
         panic!("ERROR! {}", hqth.session.error);
     } else {
-        println!("\n{} (HamQTH)", hqth.search.callsign);
+        println!("\n{} (HamQTH)", hqth.search.callsign.to_uppercase());
         println!("  Name: {}", hqth.search.adr_name);
-        println!("  Location: {}, {}, {}", hqth.search.adr_city, hqth.search.us_state, hqth.search.adr_country);
+        if !hqth.search.email.is_empty() {
+            println!("  Email: {}", hqth.search.email);
+        }
+        if !hqth.search.adr_street1.is_empty() {
+            println!("  Address: {}", hqth.search.adr_street1);
+        }
+        if !hqth.search.adr_city.is_empty() {
+            if !hqth.search.us_state.is_empty() {
+                println!("  Location: {}, {} {}", hqth.search.adr_city, hqth.search.us_state, hqth.search.adr_zip);
+            }
+            else {
+                println!("  Location: {}", hqth.search.adr_city);
+            }
+        }
+        println!("  Country: {}", hqth.search.adr_country);
         Ok(())
     }
 }

--- a/src/qrz.rs
+++ b/src/qrz.rs
@@ -318,8 +318,24 @@ pub fn query(callsign: &str) -> Result<(), reqwest::Error> {
     } else {
         println!("\n{} (QRZ)", qrzdb.callsign.call);
         println!("  Name: {} {}", qrzdb.callsign.fname, qrzdb.callsign.name);
-        println!("  Location: {}, {}, {}", qrzdb.callsign.addr2, qrzdb.callsign.state, qrzdb.callsign.land);
-        println!("  Class: {}", qrzdb.callsign.class);
+        if !qrzdb.callsign.email.is_empty() {
+            println!("  Email: {}", qrzdb.callsign.email);
+        }
+        if !qrzdb.callsign.addr1.is_empty() {
+            println!("  Address: {}", qrzdb.callsign.addr1);
+        }
+        if !qrzdb.callsign.addr2.is_empty() {
+            if !qrzdb.callsign.state.is_empty() {
+                println!("  Location: {}, {} {}", qrzdb.callsign.addr2, qrzdb.callsign.state, qrzdb.callsign.zip);
+            }
+            else {
+                println!("  Location: {}", qrzdb.callsign.addr2);
+            }
+        }
+        println!("  Country: {}", qrzdb.callsign.land);
+        if !qrzdb.callsign.class.is_empty() {
+            println!("  Class: {}", qrzdb.callsign.class);
+        }
         Ok(())
     }
 }
@@ -342,7 +358,7 @@ pub fn dxcc(entity: &str) -> Result<(), reqwest::Error> {
             Err(_e) => panic!("error")
         };
 
-        query(entity)?;
+        dxcc(entity)?;
         Ok(())
     } else if qrzdb.session.error != "" {
         panic!("ERROR! {}", qrzdb.session.error);


### PR DESCRIPTION
Adds additional address information and email output from both QRZ and HamQTH and does a few additional checks to not output empty parts.